### PR TITLE
Prevent throwing from pusher destructor.

### DIFF
--- a/src/blackhole/config.hpp
+++ b/src/blackhole/config.hpp
@@ -23,9 +23,7 @@
 #define BLACKHOLE_HAS_ATTRIBUTE_TID
 
 // Add lightweight process id attribute to every logging event. Attribute has integer type.
-#ifndef BLACKHOLE_HAS_ATTRIBUTE_LWP
-    #undef BLACKHOLE_HAS_ATTRIBUTE_LWP
-#endif
+#undef  BLACKHOLE_HAS_ATTRIBUTE_LWP
 
 #define BLACKHOLE_INTERNAL_SET_RESERVED_SIZE 6
 #define BLACKHOLE_EXTERNAL_SET_RESERVED_SIZE 16

--- a/src/blackhole/detail/logger/pusher.hpp
+++ b/src/blackhole/detail/logger/pusher.hpp
@@ -3,6 +3,7 @@
 #include <type_traits>
 #include <tuple>
 #include <ostream>
+#include <exception>
 
 #include "blackhole/detail/traits/attributes/pack/feeder.hpp"
 #include "blackhole/keyword/message.hpp"
@@ -40,7 +41,13 @@ public:
     }
 
     ~pusher_t() {
-        log.push(std::move(record));
+        //In Debug builds push can throw.
+        try {
+            log.push(std::move(record));
+        }
+        catch (const std::exception& e) {
+            std::cout << "Exception caught in pusher destructor: " << e.what() << std::endl;
+        }
     }
 
     /*!

--- a/src/blackhole/error/handler.hpp
+++ b/src/blackhole/error/handler.hpp
@@ -16,9 +16,6 @@ typedef std::function<void()> exception_handler_t;
 class default_exception_handler_t {
 public:
     void operator()() const {
-#ifdef BLACKHOLE_DEBUG
-        throw;
-#else
         try {
             throw;
         } catch (const std::exception& err) {
@@ -26,6 +23,9 @@ public:
         } catch (...) {
             std::cout << "logging core error occurred: unknown" << std::endl;
         }
+        //First we make a message about core error and then rethrow in debug
+#ifdef BLACKHOLE_DEBUG
+        throw;
 #endif
     }
 };

--- a/src/blackhole/logger.hpp
+++ b/src/blackhole/logger.hpp
@@ -79,6 +79,7 @@ public:
         using std::swap;
         swap(d.filter, other.d.filter);
         swap(d.frontends, other.d.frontends);
+        swap(d.exception, other.d.exception);
 
         scoped.swap(other.scoped);
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ SET(SOURCES_BASE
     datetime/test_Week
     logger/composite
     logger/verbose
+    logger/pusher
     test_AttachableStream
     test_Attribute
     test_Config

--- a/src/tests/logger/pusher.cpp
+++ b/src/tests/logger/pusher.cpp
@@ -1,0 +1,24 @@
+#include <blackhole/logger.hpp>
+#include <blackhole/detail/logger/pusher.hpp>
+
+#include "../global.hpp"
+#include "../mocks/logger.hpp"
+
+using namespace blackhole;
+
+TEST(pusher_t, Constructor) {
+    mock::verbose_log_t<level> log;
+    record_t record;
+    const char* msg = "test msg";
+    aux::logger::pusher_t<decltype(log)> pusher(log, record, msg);
+    EXPECT_CALL(log, push(_)).WillOnce(Throw(std::logic_error("mock exception")));
+}
+
+TEST(pusher_t, VarArgsConstructor) {
+    mock::verbose_log_t<level> log;
+    record_t record;
+    const char* msg = "test msg. Data %s";
+    const char* data = "DATA";
+    aux::logger::pusher_t<decltype(log)> pusher(log, record, msg, data);
+    EXPECT_CALL(log, push(_)).WillOnce(Throw(std::logic_error("mock exception")));
+}

--- a/src/tests/logger/verbose.cpp
+++ b/src/tests/logger/verbose.cpp
@@ -21,14 +21,33 @@ TEST(verbose_logger_t, ConstructorEnumClass) {
 
 TEST(verbose_logger_t, MoveExplicitConstructor) {
     verbose_logger_t<testing::level> log(testing::info);
+    std::unique_ptr<mock::frontend_t> frontend(new mock::frontend_t());
+    mock::frontend_t& frontend_ref(*frontend);
+    EXPECT_CALL(frontend_ref, handle(_)).
+            WillRepeatedly(Throw(std::logic_error("Mock exception")));
+    log.add_frontend(std::move(frontend));
     verbose_logger_t<testing::level> other(std::move(log));
-
+#ifdef BLACKHOLE_DEBUG
+    EXPECT_THROW(other.push(record_t()), std::logic_error);
+#else
+    EXPECT_NO_THROW(other.push(record));
+#endif
     EXPECT_EQ(testing::info, other.verbosity());
 }
 
 TEST(verbose_logger_t, MoveImplicitConstructor) {
     verbose_logger_t<testing::level> log(testing::info);
+    std::unique_ptr<mock::frontend_t> frontend(new mock::frontend_t());
+    mock::frontend_t& frontend_ref(*frontend);
+    EXPECT_CALL(frontend_ref, handle(_)).
+            WillRepeatedly(Throw(std::logic_error("Mock exception")));
+    log.add_frontend(std::move(frontend));
     verbose_logger_t<testing::level> other = std::move(log);
+#ifdef BLACKHOLE_DEBUG
+    EXPECT_THROW(other.push(record_t()), std::logic_error);
+#else
+    EXPECT_NO_THROW(other.push(record));
+#endif
 
     EXPECT_EQ(testing::info, other.verbosity());
 }


### PR DESCRIPTION
On debug builds there is a possibility of throwing an excepion from pusher destructor. Patch fixes this and adds more verbose logging of exceptions.