### PR TITLE
Make {value_t,view_t} visitors work

### DIFF
--- a/include/blackhole/attribute.hpp
+++ b/include/blackhole/attribute.hpp
@@ -149,7 +149,7 @@ public:
     auto operator=(value_t&& other) -> value_t&;
 
     /// Applies the given visitor to perform pattern matching.
-    auto apply(const visitor_t& visitor) const -> void;
+    auto apply(visitor_t& visitor) const -> void;
 
     /// Returns the internal underlying value.
     auto inner() noexcept -> inner_t&;
@@ -289,7 +289,7 @@ public:
     auto operator=(view_t&& other) -> view_t& = default;
 
     /// Applies the given visitor to perform pattern matching.
-    auto apply(const visitor_t& visitor) const -> void;
+    auto apply(visitor_t& visitor) const -> void;
 
     auto operator==(const view_t& other) const -> bool;
     auto operator!=(const view_t& other) const -> bool;

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -46,6 +46,9 @@ struct from {
 static_assert(sizeof(value_t::inner_t) <= sizeof(value_t), "padding or alignment violation");
 static_assert(sizeof(view_t::inner_t) <= sizeof(view_t), "padding or alignment violation");
 
+// visitor_t destructor called by destructors of derived classes
+value_t::visitor_t::~visitor_t() {}
+
 value_t::value_t() {
     construct(nullptr);
 }
@@ -166,6 +169,9 @@ template auto get<value_t::sint64_type>(const value_t& value) -> const value_t::
 template auto get<value_t::uint64_type>(const value_t& value) -> const value_t::uint64_type&;
 template auto get<value_t::double_type>(const value_t& value) -> const value_t::double_type&;
 template auto get<value_t::string_type>(const value_t& value) -> const value_t::string_type&;
+
+// visitor_t destructor called by destructors of derived classes
+view_t::visitor_t::~visitor_t() {}
 
 view_t::view_t() {
     construct(nullptr);

--- a/src/attribute.cpp
+++ b/src/attribute.cpp
@@ -29,6 +29,18 @@ struct into_view {
     }
 };
 
+template<class Value>
+struct from {
+    typedef void result_type;
+
+    typename Value::visitor_t &visitor;
+
+    template<typename T>
+    auto operator()(const T& value) const -> void {
+        visitor(value);
+    }
+};
+
 }  // namespace
 
 static_assert(sizeof(value_t::inner_t) <= sizeof(value_t), "padding or alignment violation");
@@ -116,6 +128,10 @@ auto value_t::operator=(value_t&& other) -> value_t& {
 
 value_t::~value_t() {
     inner().~inner_t();
+}
+
+auto value_t::apply(visitor_t& visitor) const -> void {
+    boost::apply_visitor(from<value_t>{visitor}, inner().value);
 }
 
 auto value_t::inner() noexcept -> inner_t& {
@@ -225,6 +241,10 @@ view_t::view_t(const value_t& value) {
 
 auto view_t::operator==(const view_t& other) const -> bool {
     return inner().value == other.inner().value;
+}
+
+auto view_t::apply(visitor_t& visitor) const -> void {
+    boost::apply_visitor(from<view_t>{visitor}, inner().value);
 }
 
 auto view_t::inner() noexcept -> inner_t& {

--- a/src/root.cpp
+++ b/src/root.cpp
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <iostream>
 #include <mutex>
+#include <iostream>
 
 #include <boost/thread/tss.hpp>
 


### PR DESCRIPTION
For consideration only.

Those changes are required to build cocaine-framework-native.

Also, question: does `value_t::~visitor_t` have to be part of visitor interface? Because blackhole never holds or frees visitor objects itself, so it seems virtual destructor should not be required.