### PR TITLE
1.0.0-0alpha7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,7 @@ add_library(${LIBRARY_NAME} SHARED
 	src/sink/console
 	src/sink/file
 	src/sink/null
+	src/sink/socket/tcp
 	src/sink/socket/udp
 	src/wrapper)
 
@@ -205,6 +206,7 @@ if (ENABLE_TESTING)
 		tests/handler/blocking
 		tests/record
 		tests/registry
+		tests/sink/tcp
 		tests/root
 		tests/severity
 		tests/sink/console

--- a/README.md
+++ b/README.md
@@ -139,7 +139,9 @@ JSON formatter provides an ability to format a logging record into a structured 
 
 ## Sinks
 
-- Null.
+### Null
+Sometimes we need to just drop all logging events no matter what, for example to benchmarking purposes. For these cases there is null appender, which just ignores all records.
+
 - Stream.
 - Term.
 - File.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,20 @@ Sometimes we need to just drop all logging events no matter what, for example to
 - Stream.
 - Term.
 - File.
-- Socket.
+
+### Socket
+The socket sinks category contains sinks that write their output to a remote destination specified by a host and port. Currently the data can be sent over either TCP or UDP.
+
+#### TCP
+This appender emits formatted logging events using connected TCP socket.
+
+| Option | Type  | Description|
+|--------|:-----:|------------|
+|host    |string | **Required**.<br/> The name or address of the system that is listening for log events. |
+|port    |u16    | **Required**.<br/> The port on the host that is listening for log events. |
+
+#### UDP
+Nuff said.
 
 ## Runtime Type Information
 

--- a/bench/attribute.cpp
+++ b/bench/attribute.cpp
@@ -16,7 +16,19 @@ static void view_ctor_get_int64(::benchmark::State& state) {
     state.SetItemsProcessed(state.iterations());
 }
 
+static void from_owned(::benchmark::State& state) {
+    blackhole::attribute::value_t owned(42);
+
+    while (state.KeepRunning()) {
+        blackhole::attribute::view_t view(owned);
+        ::benchmark::DoNotOptimize(view);
+    }
+
+    state.SetItemsProcessed(state.iterations());
+}
+
 NBENCHMARK("attribute.view_t[ctor + get<i64>]", view_ctor_get_int64);
+NBENCHMARK("attribute.view_t[ctor + from owned]", from_owned);
 
 }  // namespace benchmark
 }  // namespace blackhole

--- a/bench/attribute.cpp
+++ b/bench/attribute.cpp
@@ -27,8 +27,20 @@ static void from_owned(::benchmark::State& state) {
     state.SetItemsProcessed(state.iterations());
 }
 
+static void from_owned_string(::benchmark::State& state) {
+    blackhole::attribute::value_t owned("le message");
+
+    while (state.KeepRunning()) {
+        blackhole::attribute::view_t view(owned);
+        ::benchmark::DoNotOptimize(view);
+    }
+
+    state.SetItemsProcessed(state.iterations());
+}
+
 NBENCHMARK("attribute.view_t[ctor + get<i64>]", view_ctor_get_int64);
 NBENCHMARK("attribute.view_t[ctor + from owned]", from_owned);
+NBENCHMARK("attribute.view_t[ctor + from owned string]", from_owned_string);
 
 }  // namespace benchmark
 }  // namespace blackhole

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,8 @@ blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
   * Feature: JSON formatter now inserts process and thread id fields.
   * Feature: flush interval option can now be specified in a config to the file
     appender.
+  * Feature: added blocking TCP appender to be able to emit log messages via
+    TCP socket.
 
  -- Evgeny Safronov <division494@gmail.com>  Thu, 11 Feb 2016 21:18:38 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -7,9 +7,9 @@ blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
     TCP socket.
   * API: remove filtering from sink interface, because the filtering concept
     needed to reviewed completely.
-    For example before this change every sink just returned `true` regardless
-    whatever. This information gave nothing, because otherwise all users must
-    check before emitting messages while they can just emit. Furthermore we
+    Before this change every sink just returned `true` no matter what. This
+    information gave nothing, because otherwise all users must check before
+    emitting messages while they can just emit. Instead of this we'd better
     introduce custom filters for sinks that can be applied using special
     filtering decorator.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -5,6 +5,13 @@ blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
     appender.
   * Feature: added blocking TCP appender to be able to emit log messages via
     TCP socket.
+  * API: remove filtering from sink interface, because the filtering concept
+    needed to reviewed completely.
+    For example before this change every sink just returned `true` regardless
+    whatever. This information gave nothing, because otherwise all users must
+    check before emitting messages while they can just emit. Furthermore we
+    introduce custom filters for sinks that can be applied using special
+    filtering decorator.
 
  -- Evgeny Safronov <division494@gmail.com>  Thu, 11 Feb 2016 21:18:38 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
 
   * Feature: JSON formatter now inserts process and thread id fields.
+  * Feature: flush interval option can now be specified in a config to the file
+    appender.
 
  -- Evgeny Safronov <division494@gmail.com>  Thu, 11 Feb 2016 21:18:38 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
+
+  * Feature: JSON formatter now inserts process and thread id fields.
+
+ -- Evgeny Safronov <division494@gmail.com>  Thu, 11 Feb 2016 21:18:38 +0300
+
 blackhole (1.0.0-0alpha6) unstable; urgency=low
 
   * Feature: completely hide rapidjson symbols.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-blackhole (1.0.0-0alpha7) UNRELEASED; urgency=low
+blackhole (1.0.0-0alpha7) unstable; urgency=low
 
   * Feature: JSON formatter now inserts process and thread id fields.
   * Feature: flush interval option can now be specified in a config to the file

--- a/include/blackhole/config/node.hpp
+++ b/include/blackhole/config/node.hpp
@@ -27,30 +27,42 @@ public:
     virtual ~node_t() = 0;
 
     /// Tries to convert the underlying object to bool.
+    ///
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_bool() const -> bool = 0;
 
     /// Tries to convert the underlying object to signed integer.
+    ///
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_sint64() const -> std::int64_t = 0;
 
     /// Tries to convert the underlying object to unsigned integer.
+    ///
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_uint64() const -> std::uint64_t = 0;
 
     /// Tries to convert the underlying object to double.
+    ///
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_double() const -> double = 0;
 
     /// Tries to convert the underlying object to string.
+    ///
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_string() const -> std::string = 0;
 
     /// Assuming that the underlying object is an array, performs inner iteration over it by
     /// applying the given function to each element.
     ///
-    /// Should do nothing either if there is no underlying array or it is empty.
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
+    /// Should do nothing if the underlying array is empty.
     virtual auto each(const each_function& fn) const -> void = 0;
 
     /// Assuming that the underlying object is a map, performs inner iteration over it by applying
     /// the given function to each key-value element.
     ///
-    /// Should do nothing either if there is no underlying map or it is empty.
+    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
+    /// Should do nothing if the underlying map is empty.
     virtual auto each_map(const member_function& fn) const -> void = 0;
 
     /// Assuming that the underlying object is an array performs index operation returning the

--- a/include/blackhole/config/node.hpp
+++ b/include/blackhole/config/node.hpp
@@ -26,6 +26,14 @@ public:
 public:
     virtual ~node_t() = 0;
 
+    virtual auto is_bool() const noexcept -> bool = 0;
+    virtual auto is_sint64() const noexcept -> bool = 0;
+    virtual auto is_uint64() const noexcept -> bool = 0;
+    virtual auto is_double() const noexcept -> bool = 0;
+    virtual auto is_string() const noexcept -> bool { return false; }
+    virtual auto is_vector() const noexcept -> bool { return false; }
+    virtual auto is_object() const noexcept -> bool { return false; }
+
     /// Tries to convert the underlying object to bool.
     ///
     /// Implementations are free to throw exceptions on either type mismatch or whatever else.

--- a/include/blackhole/config/node.hpp
+++ b/include/blackhole/config/node.hpp
@@ -18,6 +18,9 @@ class option;
 /// using tree data structure, like JSON, XML or YAML.
 /// To be able to initialize from your own data format you must create subclass and implement its
 /// converting methods as like as tree traversing using subscription operators.
+///
+/// Implementations are free to throw exceptions inside conversion methods on either type mismatch
+/// or whatever else.
 class node_t {
 public:
     typedef std::function<auto(const node_t& node) -> void> each_function;
@@ -35,41 +38,29 @@ public:
     virtual auto is_object() const noexcept -> bool { return false; }
 
     /// Tries to convert the underlying object to bool.
-    ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_bool() const -> bool = 0;
 
     /// Tries to convert the underlying object to signed integer.
-    ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_sint64() const -> std::int64_t = 0;
 
     /// Tries to convert the underlying object to unsigned integer.
-    ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_uint64() const -> std::uint64_t = 0;
 
     /// Tries to convert the underlying object to double.
-    ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_double() const -> double = 0;
 
     /// Tries to convert the underlying object to string.
-    ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     virtual auto to_string() const -> std::string = 0;
 
     /// Assuming that the underlying object is an array, performs inner iteration over it by
     /// applying the given function to each element.
     ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     /// Should do nothing if the underlying array is empty.
     virtual auto each(const each_function& fn) const -> void = 0;
 
     /// Assuming that the underlying object is a map, performs inner iteration over it by applying
     /// the given function to each key-value element.
     ///
-    /// Implementations are free to throw exceptions on either type mismatch or whatever else.
     /// Should do nothing if the underlying map is empty.
     virtual auto each_map(const member_function& fn) const -> void = 0;
 

--- a/include/blackhole/config/node.hpp
+++ b/include/blackhole/config/node.hpp
@@ -33,9 +33,9 @@ public:
     virtual auto is_sint64() const noexcept -> bool = 0;
     virtual auto is_uint64() const noexcept -> bool = 0;
     virtual auto is_double() const noexcept -> bool = 0;
-    virtual auto is_string() const noexcept -> bool { return false; }
-    virtual auto is_vector() const noexcept -> bool { return false; }
-    virtual auto is_object() const noexcept -> bool { return false; }
+    virtual auto is_string() const noexcept -> bool = 0;
+    virtual auto is_vector() const noexcept -> bool = 0;
+    virtual auto is_object() const noexcept -> bool = 0;
 
     /// Tries to convert the underlying object to bool.
     virtual auto to_bool() const -> bool = 0;

--- a/include/blackhole/detail/config/json.hpp
+++ b/include/blackhole/detail/config/json.hpp
@@ -68,8 +68,36 @@ public:
         cursor(std::move(cursor))
     {}
 
+    auto is_bool() const noexcept -> bool {
+        return value.IsBool();
+    }
+
+    auto is_sint64() const noexcept -> bool {
+        return value.IsInt64();
+    }
+
+    auto is_uint64() const noexcept -> bool {
+        return value.IsUint64();
+    }
+
+    auto is_double() const noexcept -> bool {
+        return value.IsDouble();
+    }
+
+    auto is_string() const noexcept -> bool {
+        return value.IsString();
+    }
+
+    auto is_vector() const noexcept -> bool {
+        return value.IsArray();
+    }
+
+    auto is_object() const noexcept -> bool {
+        return value.IsObject();
+    }
+
     auto to_bool() const -> bool {
-        if (value.IsBool()) {
+        if (is_bool()) {
             return value.GetBool();
         }
 
@@ -77,7 +105,7 @@ public:
     }
 
     auto to_sint64() const -> std::int64_t {
-        if (value.IsInt64()) {
+        if (is_sint64()) {
             return value.GetInt64();
         }
 
@@ -85,7 +113,7 @@ public:
     }
 
     auto to_uint64() const -> std::uint64_t {
-        if (value.IsUint64()) {
+        if (is_uint64()) {
             return value.GetUint64();
         }
 
@@ -93,7 +121,7 @@ public:
     }
 
     auto to_double() const -> double {
-        if (value.IsDouble()) {
+        if (is_double()) {
             return value.GetDouble();
         }
 
@@ -101,7 +129,7 @@ public:
     }
 
     auto to_string() const -> std::string {
-        if (value.IsString()) {
+        if (is_string()) {
             return value.GetString();
         }
 

--- a/include/blackhole/detail/sink/file.hpp
+++ b/include/blackhole/detail/sink/file.hpp
@@ -62,6 +62,10 @@ public:
 
     virtual ~inner_t() {}
 
+    auto path() const noexcept -> const std::string& {
+        return data.filename;
+    }
+
     auto interval() const noexcept -> std::size_t {
         return data.interval;
     }

--- a/include/blackhole/detail/sink/socket/tcp.hpp
+++ b/include/blackhole/detail/sink/socket/tcp.hpp
@@ -1,0 +1,116 @@
+#pragma once
+
+#include <mutex>
+
+#include <boost/asio/connect.hpp>
+#include <boost/asio/io_service.hpp>
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/write.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/optional/optional.hpp>
+
+#include "blackhole/config/node.hpp"
+#include "blackhole/config/option.hpp"
+#include "blackhole/cpp17/string_view.hpp"
+#include "blackhole/extensions/format.hpp"
+#include "blackhole/sink.hpp"
+#include "blackhole/sink/socket/tcp.hpp"
+
+namespace blackhole {
+inline namespace v1 {
+namespace sink {
+namespace socket {
+namespace {
+
+/// Resolves specified host and tries to connect to the socket.
+template<typename Protocol>
+auto connect(boost::asio::io_service& ev, typename Protocol::socket& socket,
+    const std::string& host, std::uint16_t port) -> void
+{
+    typename Protocol::resolver::iterator endpoint;
+
+    try {
+        typename Protocol::resolver resolver(ev);
+        typename Protocol::resolver::query query(host, boost::lexical_cast<std::string>(port),
+            Protocol::resolver::query::flags::numeric_service);
+        endpoint = resolver.resolve(query);
+    } catch (const boost::system::system_error& err) {
+        throw std::system_error(err.code().value(), std::system_category(),
+            fmt::format("failed to resolve {}:{} - {}", host, port, err.what()));
+    }
+
+    try {
+        boost::asio::connect(socket, endpoint);
+    } catch (const boost::system::system_error& err) {
+        throw std::system_error(err.code().value(), std::system_category(),
+            fmt::format("failed to connect to {}:{} - {}", host, port, err.what()));
+    }
+}
+
+}  // namespace
+
+class tcp_t : public sink_t {
+    typedef boost::asio::ip::tcp protocol_type;
+    typedef protocol_type::socket socket_type;
+    typedef protocol_type::endpoint endpoint_type;
+
+    struct data_t {
+        std::string host;
+        std::uint16_t port;
+
+        boost::asio::io_service io_service;
+        std::unique_ptr<socket_type> socket;
+
+        mutable std::mutex mutex;
+    };
+
+    std::unique_ptr<data_t> data;
+
+public:
+    tcp_t(std::string host, std::uint16_t port) :
+        data(new data_t)
+    {
+        data->host = std::move(host);
+        data->port = port;
+    }
+
+    auto host() const noexcept -> const std::string& {
+        return data->host;
+    }
+
+    auto port() const noexcept -> std::uint16_t {
+        return data->port;
+    }
+
+    auto filter(const record_t&) -> bool {
+        return true;
+    }
+
+    auto emit(const record_t&, const string_view& message) -> void {
+        std::lock_guard<std::mutex> lock(data->mutex);
+
+        if (!data->socket) {
+            data->socket = reconnect(lock);
+        }
+
+        try {
+            boost::asio::write(*data->socket, boost::asio::buffer(message.data(), message.size()));
+        } catch (const boost::system::system_error&) {
+            data->socket.reset();
+            std::rethrow_exception(std::current_exception());
+        }
+    }
+
+private:
+    auto reconnect(std::lock_guard<std::mutex>&) -> std::unique_ptr<socket_type> {
+        auto socket = std::unique_ptr<socket_type>(new socket_type(data->io_service));
+        connect<protocol_type>(data->io_service, *socket, host(), port());
+
+        return socket;
+    }
+};
+
+}  // namespace socket
+}  // namespace sink
+}  // namespace v1
+}  // namespace blackhole

--- a/include/blackhole/detail/sink/socket/tcp.hpp
+++ b/include/blackhole/detail/sink/socket/tcp.hpp
@@ -82,10 +82,6 @@ public:
         return data->port;
     }
 
-    auto filter(const record_t&) -> bool {
-        return true;
-    }
-
     auto emit(const record_t&, const string_view& message) -> void {
         std::lock_guard<std::mutex> lock(data->mutex);
 

--- a/include/blackhole/detail/sink/socket/tcp.hpp
+++ b/include/blackhole/detail/sink/socket/tcp.hpp
@@ -20,7 +20,8 @@ namespace blackhole {
 inline namespace v1 {
 namespace sink {
 namespace socket {
-namespace {
+
+namespace detail {
 
 /// Resolves specified host and tries to connect to the socket.
 template<typename Protocol>
@@ -100,7 +101,7 @@ public:
 private:
     auto reconnect(std::lock_guard<std::mutex>&) -> std::unique_ptr<socket_type> {
         auto socket = std::unique_ptr<socket_type>(new socket_type(data->io_service));
-        connect<protocol_type>(data->io_service, *socket, host(), port());
+        detail::connect<protocol_type>(data->io_service, *socket, host(), port());
 
         return socket;
     }

--- a/include/blackhole/detail/util/optional.hpp
+++ b/include/blackhole/detail/util/optional.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <boost/optional/optional_fwd.hpp>
+
+namespace blackhole {
+inline namespace v1 {
+namespace detail {
+namespace util {
+
+/// This hack is required because of `boost::optional` 1.46, which I have to support and which
+/// can not map on none value.
+template<typename T, typename F>
+auto value_or(const boost::optional<T>& optional, F fn) -> T {
+    if (optional) {
+        return optional.get();
+    } else {
+        return fn();
+    }
+}
+
+}  // namespace util
+}  // namespace detail
+}  // namespace v1
+}  // namespace blackhole

--- a/include/blackhole/sink.hpp
+++ b/include/blackhole/sink.hpp
@@ -28,8 +28,6 @@ public:
     auto operator=(const sink_t& other) -> sink_t& = default;
     auto operator=(sink_t&& other) -> sink_t& = default;
 
-    virtual auto filter(const record_t& record) -> bool = 0;
-
     virtual auto emit(const record_t& record, const string_view& message) -> void = 0;
 };
 

--- a/include/blackhole/sink/console.hpp
+++ b/include/blackhole/sink/console.hpp
@@ -124,12 +124,6 @@ public:
     /// \param colormap color mappings from logging level to terminal color.
     console_t(type_t type, termcolor_map colormap);
 
-    /// Filters the given log record determining if it is allowed to be consumed by this sink.
-    ///
-    /// The console implementation always returns `true`, meaning that all logging events should be
-    /// accepted.
-    auto filter(const record_t& record) -> bool;
-
     /// Writes the formatted message into the attached output stream.
     ///
     /// Note that the message may be anticipatorily colored using severity information from the

--- a/include/blackhole/sink/file.hpp
+++ b/include/blackhole/sink/file.hpp
@@ -108,7 +108,17 @@ public:
     auto operator=(const builder_t& other) -> builder_t& = delete;
     auto operator=(builder_t&& other) noexcept -> builder_t&;
 
+    /// Specifies a flush interval in terms of write operations.
+    ///
+    /// Logging backend will flush its internal buffers after at least every count writes, but the
+    /// underlying implementation can decide to do it more often. Note that 0 value means automatic
+    /// policy.
+    ///
+    /// \param count flush interval.
     auto interval(std::size_t count) -> builder_t&;
+
+    // TODO:
+    // auto interval(bytesize_t size) -> builder_t&
 
     auto build() -> file_t;
 };

--- a/include/blackhole/sink/file.hpp
+++ b/include/blackhole/sink/file.hpp
@@ -72,6 +72,13 @@ public:
     /// Assigns the given file sink to the current one by moving its content.
     auto operator=(file_t&& other) noexcept -> file_t&;
 
+    /// Returns a const lvalue referente to destination path pattern.
+    ///
+    /// The path can contain attribute placeholders, meaning that the real destination name will be
+    /// deduced at runtime using provided log record. No real file will be opened at construction
+    /// time.
+    auto path() const -> const std::string&;
+
     /// Filters the given log record determining if it is allowed to be consumed by this sink.
     ///
     /// The file sink implementation always returns `true`, meaning that all logging events should

--- a/include/blackhole/sink/file.hpp
+++ b/include/blackhole/sink/file.hpp
@@ -79,12 +79,6 @@ public:
     /// time.
     auto path() const -> const std::string&;
 
-    /// Filters the given log record determining if it is allowed to be consumed by this sink.
-    ///
-    /// The file sink implementation always returns `true`, meaning that all logging events should
-    /// be accepted.
-    auto filter(const record_t& record) -> bool;
-
     /// Outputs the formatted message with its associated record to the file.
     ///
     /// Depending on the filename pattern it is possible to write into multiple destinations.

--- a/include/blackhole/sink/null.hpp
+++ b/include/blackhole/sink/null.hpp
@@ -30,12 +30,9 @@ namespace sink {
 /// This class exists primarily for benchmarking reasons to measure the entire logging processing
 /// pipeline. It never fails and never throws, because it does nothing.
 ///
-/// All methods of this class are thread safe.
+/// \remark All methods of this class are thread safe.
 class null_t : public sink_t {
 public:
-    /// Returns `false` regardless of a log record value, causing any log event to be dropped.
-    auto filter(const record_t& record) -> bool;
-
     /// Drops any incoming log event.
     auto emit(const record_t& record, const string_view& formatted) -> void;
 };

--- a/include/blackhole/sink/socket/tcp.hpp
+++ b/include/blackhole/sink/socket/tcp.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+
+namespace blackhole {
+inline namespace v1 {
+
+template<typename>
+struct factory;
+
+}  // namespace v1
+}  // namespace blackhole
+
+namespace blackhole {
+inline namespace v1 {
+namespace config {
+
+class node_t;
+
+}  // namespace config
+}  // namespace v1
+}  // namespace blackhole
+
+namespace blackhole {
+inline namespace v1 {
+namespace sink {
+namespace socket {
+
+/// The TCP socket sink is a sink that writes its output to a remote destination specified by a host
+/// and port.
+///
+/// \remark All methods of this class are thread-safe.
+class tcp_t;
+
+}  // namespace socket
+}  // namespace sink
+
+template<>
+struct factory<sink::socket::tcp_t> {
+    static auto type() -> const char*;
+    static auto from(const config::node_t& config) -> sink::socket::tcp_t;
+};
+
+}  // namespace v1
+}  // namespace blackhole

--- a/include/blackhole/sink/socket/udp.hpp
+++ b/include/blackhole/sink/socket/udp.hpp
@@ -73,8 +73,6 @@ public:
     /// \note you should manually include the appropriate boost header files when using this method.
     auto endpoint() const -> const endpoint_type&;
 
-    auto filter(const record_t& record) -> bool;
-
     /// Emits a datagram to the specified endpoint.
     auto emit(const record_t& record, const string_view& message) -> void;
 };

--- a/src/formatter/json.cpp
+++ b/src/formatter/json.cpp
@@ -189,6 +189,17 @@ public:
         apply("process", record.pid());
     }
 
+    auto thread() -> void {
+        writer_t wr;
+        // TODO: Encapsulate.
+#ifdef __linux__
+            wr.write("{:#x}", record.tid());
+#elif __APPLE__
+            wr.write("{:#x}", reinterpret_cast<unsigned long>(record.tid()));
+#endif
+        apply("thread", wr.inner.data(), wr.inner.size());
+    }
+
     auto severity() -> void {
         apply("severity", static_cast<std::int64_t>(record.severity()));
     }
@@ -309,6 +320,7 @@ auto json_t::format(const record_t& record, writer_t& writer) -> void {
 
     auto builder = inner->create(root, record);
     builder.message();
+    builder.thread();
     builder.process();
     builder.severity();
     builder.timestamp();

--- a/src/formatter/json.cpp
+++ b/src/formatter/json.cpp
@@ -185,6 +185,10 @@ public:
         apply("message", record.formatted());
     }
 
+    auto process() -> void {
+        apply("process", record.pid());
+    }
+
     auto severity() -> void {
         apply("severity", static_cast<std::int64_t>(record.severity()));
     }
@@ -305,6 +309,7 @@ auto json_t::format(const record_t& record, writer_t& writer) -> void {
 
     auto builder = inner->create(root, record);
     builder.message();
+    builder.process();
     builder.severity();
     builder.timestamp();
     builder.attributes();

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -14,6 +14,9 @@
 #include "blackhole/sink.hpp"
 #include "blackhole/sink/console.hpp"
 #include "blackhole/sink/null.hpp"
+#include "blackhole/sink/socket/tcp.hpp"
+
+#include "blackhole/detail/sink/socket/tcp.hpp"
 
 namespace blackhole {
 inline namespace v1 {
@@ -113,6 +116,7 @@ auto registry_t::configured() -> registry_t {
 
     registry.add<sink::console_t>();
     registry.add<sink::null_t>();
+    registry.add<sink::socket::tcp_t>();
 
     registry.add<handler::blocking_t>();
 

--- a/src/sink/console.cpp
+++ b/src/sink/console.cpp
@@ -137,10 +137,6 @@ console_t::console_t(std::ostream& stream, termcolor_map colormap) :
     colormap(std::move(colormap))
 {}
 
-auto console_t::filter(const record_t&) -> bool {
-    return true;
-}
-
 auto console_t::emit(const record_t& record, const string_view& formatted) -> void {
     if (isatty(stream)) {
         std::lock_guard<std::mutex> lock(mutex);

--- a/src/sink/file.cpp
+++ b/src/sink/file.cpp
@@ -83,13 +83,21 @@ auto factory<sink::file_t>::type() -> const char* {
 }
 
 auto factory<sink::file_t>::from(const config::node_t& config) -> sink::file_t {
-    auto filename = config["path"].to_string();
+    const auto filename = config["path"].to_string();
 
     if (!filename) {
-        throw std::logic_error("field 'path' is required");
+        throw std::invalid_argument("field 'path' is required");
     }
 
-    return sink::file_t(std::move(filename.get()));
+    sink::file_t::builder_t builder(filename.get());
+
+    if (auto flush = config["flush"]) {
+        if (auto value = flush.to_uint64()) {
+            builder.interval(value.get());
+        }
+    }
+
+    return builder.build();
 }
 
 }  // namespace v1

--- a/src/sink/file.cpp
+++ b/src/sink/file.cpp
@@ -42,6 +42,10 @@ file_t::~file_t() = default;
 
 auto file_t::operator=(file_t&& other) noexcept -> file_t& = default;
 
+auto file_t::path() const -> const std::string& {
+    return inner->path();
+}
+
 auto file_t::filter(const record_t&) -> bool {
     return true;
 }

--- a/src/sink/file.cpp
+++ b/src/sink/file.cpp
@@ -46,10 +46,6 @@ auto file_t::path() const -> const std::string& {
     return inner->path();
 }
 
-auto file_t::filter(const record_t&) -> bool {
-    return true;
-}
-
 auto file_t::emit(const record_t& record, const string_view& formatted) -> void {
     const auto filename = inner->filename(record);
 

--- a/src/sink/null.cpp
+++ b/src/sink/null.cpp
@@ -7,23 +7,15 @@ namespace blackhole {
 inline namespace v1 {
 namespace sink {
 
-auto
-null_t::filter(const record_t&) -> bool {
-    return false;
-}
-
-auto
-null_t::emit(const record_t&, const string_view&) -> void {}
+auto null_t::emit(const record_t&, const string_view&) -> void {}
 
 }  // namespace sink
 
-auto
-factory<sink::null_t>::type() -> const char* {
+auto factory<sink::null_t>::type() -> const char* {
     return "null";
 }
 
-auto
-factory<sink::null_t>::from(const config::node_t&) -> sink::null_t {
+auto factory<sink::null_t>::from(const config::node_t&) -> sink::null_t {
     return sink::null_t();
 }
 

--- a/src/sink/socket/tcp.cpp
+++ b/src/sink/socket/tcp.cpp
@@ -1,0 +1,28 @@
+#include "blackhole/sink/socket/tcp.hpp"
+
+#include "blackhole/detail/sink/socket/tcp.hpp"
+#include "blackhole/detail/util/optional.hpp"
+
+namespace blackhole {
+inline namespace v1 {
+
+using detail::util::value_or;
+
+auto factory<sink::socket::tcp_t>::type() -> const char* {
+    return "tcp";
+}
+
+auto factory<sink::socket::tcp_t>::from(const config::node_t& config) -> sink::socket::tcp_t {
+    const auto host = value_or(config["host"].to_string(), []() -> std::string {
+        throw std::invalid_argument(R"(parameter "host" is required)");
+    });
+
+    const auto port = value_or(config["port"].to_uint64(), []() -> std::uint64_t {
+        throw std::invalid_argument(R"(parameter "port" is required)");
+    });
+
+    return {host, static_cast<std::uint16_t>(port)};
+}
+
+}  // namespace v1
+}  // namespace blackhole

--- a/src/sink/socket/udp.cpp
+++ b/src/sink/socket/udp.cpp
@@ -67,10 +67,6 @@ auto udp_t::endpoint() const -> const endpoint_type& {
     return inner->endpoint();
 }
 
-auto udp_t::filter(const record_t&) -> bool {
-    return true;
-}
-
 auto udp_t::emit(const record_t&, const string_view& formatted) -> void {
     inner->write(formatted);
 }

--- a/src/sink/socket/udp.cpp
+++ b/src/sink/socket/udp.cpp
@@ -8,6 +8,8 @@
 #include "blackhole/config/option.hpp"
 #include "blackhole/cpp17/string_view.hpp"
 
+#include "blackhole/detail/util/optional.hpp"
+
 namespace blackhole {
 inline namespace v1 {
 namespace sink {
@@ -80,28 +82,15 @@ auto factory<sink::socket::udp_t>::type() -> const char* {
     return "udp";
 }
 
-namespace {
-
-/// This hack is required because of `boost::optional` 1.46, which I have to support and which
-/// can not map on none value.
-template<typename T, typename F>
-auto value_or(const boost::optional<T>& optional, F fn) -> T {
-    if (optional) {
-        return optional.get();
-    } else {
-        return fn();
-    }
-}
-
-}  // namespace
+using detail::util::value_or;
 
 auto factory<sink::socket::udp_t>::from(const config::node_t& config) -> sink::socket::udp_t {
     const auto host = value_or(config["host"].to_string(), []() -> std::string {
-        throw std::invalid_argument("parameter \"host\" is required");
+        throw std::invalid_argument(R"(parameter "host" is required)");
     });
 
     const auto port = value_or(config["port"].to_uint64(), []() -> std::uint64_t {
-        throw std::invalid_argument("parameter \"port\" is required");
+        throw std::invalid_argument(R"(parameter "port" is required)");
     });
 
     return {host, static_cast<std::uint16_t>(port)};

--- a/tests/config/json.cpp
+++ b/tests/config/json.cpp
@@ -13,6 +13,114 @@ namespace testing {
 
 using config::json_t;
 
+TEST(json_t, IsBool) {
+    const auto json = "true";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_TRUE(config.is_bool());
+    EXPECT_FALSE(config.is_sint64());
+    EXPECT_FALSE(config.is_uint64());
+    EXPECT_FALSE(config.is_double());
+    EXPECT_FALSE(config.is_string());
+    EXPECT_FALSE(config.is_vector());
+    EXPECT_FALSE(config.is_object());
+}
+
+TEST(json_t, IsInt) {
+    const auto json = "42";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_FALSE(config.is_bool());
+    EXPECT_TRUE(config.is_sint64());
+    EXPECT_TRUE(config.is_uint64());
+    EXPECT_FALSE(config.is_double());
+    EXPECT_FALSE(config.is_string());
+    EXPECT_FALSE(config.is_vector());
+    EXPECT_FALSE(config.is_object());
+}
+
+TEST(json_t, IsDouble) {
+    const auto json = "42.5";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_FALSE(config.is_bool());
+    EXPECT_FALSE(config.is_sint64());
+    EXPECT_FALSE(config.is_uint64());
+    EXPECT_TRUE(config.is_double());
+    EXPECT_FALSE(config.is_string());
+    EXPECT_FALSE(config.is_vector());
+    EXPECT_FALSE(config.is_object());
+}
+
+TEST(json_t, IsString) {
+    const auto json = R"("le value")";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_FALSE(config.is_bool());
+    EXPECT_FALSE(config.is_sint64());
+    EXPECT_FALSE(config.is_uint64());
+    EXPECT_FALSE(config.is_double());
+    EXPECT_TRUE(config.is_string());
+    EXPECT_FALSE(config.is_vector());
+    EXPECT_FALSE(config.is_object());
+}
+
+TEST(json_t, IsVector) {
+    const auto json = "[1,2,3]";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_FALSE(config.is_bool());
+    EXPECT_FALSE(config.is_sint64());
+    EXPECT_FALSE(config.is_uint64());
+    EXPECT_FALSE(config.is_double());
+    EXPECT_FALSE(config.is_string());
+    EXPECT_TRUE(config.is_vector());
+    EXPECT_FALSE(config.is_object());
+}
+
+TEST(json_t, IsObject) {
+    const auto json = "{}";
+
+    rapidjson::Document doc;
+    doc.Parse<0>(json);
+    ASSERT_FALSE(doc.HasParseError());
+
+    json_t config(doc);
+
+    EXPECT_FALSE(config.is_bool());
+    EXPECT_FALSE(config.is_sint64());
+    EXPECT_FALSE(config.is_uint64());
+    EXPECT_FALSE(config.is_double());
+    EXPECT_FALSE(config.is_string());
+    EXPECT_FALSE(config.is_vector());
+    EXPECT_TRUE(config.is_object());
+}
+
 TEST(json_t, ToBool) {
     const auto json = "true";
 

--- a/tests/formatter/json.cpp
+++ b/tests/formatter/json.cpp
@@ -125,6 +125,30 @@ TEST(json_t, FormatProcess) {
     EXPECT_EQ(::getpid(), doc["process"].GetInt());
 }
 
+TEST(json_t, FormatThread) {
+    json_t formatter;
+
+    const string_view message("value");
+    const attribute_pack pack;
+    record_t record(4, message, pack);
+    writer_t writer;
+    formatter.format(record, writer);
+
+    rapidjson::Document doc;
+    doc.Parse<0>(writer.result().to_string().c_str());
+
+    ASSERT_TRUE(doc.HasMember("thread"));
+    ASSERT_TRUE(doc["thread"].IsString());
+
+    std::ostringstream stream;
+#ifdef __linux
+    stream << std::hex << std::internal << std::showbase << std::setw(2) << std::setfill('0');
+#endif
+    stream << std::this_thread::get_id();
+
+    EXPECT_EQ(stream.str(), doc["thread"].GetString());
+}
+
 TEST(json_t, FormatAttribute) {
     json_t formatter;
 

--- a/tests/formatter/json.cpp
+++ b/tests/formatter/json.cpp
@@ -108,6 +108,23 @@ TEST(json_t, FormatTimestamp) {
     EXPECT_TRUE(doc["timestamp"].GetUint64() > 0);
 }
 
+TEST(json_t, FormatProcess) {
+    json_t formatter;
+
+    const string_view message("value");
+    const attribute_pack pack;
+    record_t record(4, message, pack);
+    writer_t writer;
+    formatter.format(record, writer);
+
+    rapidjson::Document doc;
+    doc.Parse<0>(writer.result().to_string().c_str());
+
+    ASSERT_TRUE(doc.HasMember("process"));
+    ASSERT_TRUE(doc["process"].IsInt());
+    EXPECT_EQ(::getpid(), doc["process"].GetInt());
+}
+
 TEST(json_t, FormatAttribute) {
     json_t formatter;
 

--- a/tests/include/mocks/node.hpp
+++ b/tests/include/mocks/node.hpp
@@ -13,6 +13,14 @@ class node_t : public ::blackhole::config::node_t {
     typedef ::blackhole::config::node_t super;
 
 public:
+    auto is_bool() const noexcept -> bool { return false; }
+    auto is_sint64() const noexcept -> bool { return false; }
+    auto is_uint64() const noexcept -> bool { return false; }
+    auto is_double() const noexcept -> bool { return false; }
+    auto is_string() const noexcept -> bool { return false; }
+    auto is_vector() const noexcept -> bool { return false; }
+    auto is_object() const noexcept -> bool { return false; }
+
     MOCK_CONST_METHOD0(to_bool, bool());
     MOCK_CONST_METHOD0(to_sint64, std::int64_t());
     MOCK_CONST_METHOD0(to_uint64, std::uint64_t());

--- a/tests/include/mocks/sink.hpp
+++ b/tests/include/mocks/sink.hpp
@@ -13,7 +13,6 @@ public:
     sink_t();
     ~sink_t();
 
-    MOCK_METHOD1(filter, bool(const record_t&));
     MOCK_METHOD2(emit, void(const record_t&, const string_view&));
 };
 

--- a/tests/sink/console.cpp
+++ b/tests/sink/console.cpp
@@ -136,16 +136,6 @@ TEST(console_t, NonColoredOutputToNonTTY) {
     EXPECT_EQ("expected\n", sink.stream.str());
 }
 
-TEST(console_t, FilterAcceptsAll) {
-    const string_view message("");
-    const attribute_pack pack;
-    record_t record(42, message, pack);
-
-    console_t sink;
-
-    EXPECT_TRUE(sink.filter(record));
-}
-
 TEST(console_t, Type) {
     EXPECT_EQ("console", std::string(factory<sink::console_t>::type()));
 }

--- a/tests/sink/file.cpp
+++ b/tests/sink/file.cpp
@@ -42,16 +42,6 @@ TEST(inner_t, IntervalOverflow) {
     EXPECT_EQ(0, counter);
 }
 
-TEST(file_t, FilterAcceptsAll) {
-    const string_view message("");
-    const attribute_pack pack;
-    record_t record(42, message, pack);
-
-    file_t sink("");
-
-    EXPECT_TRUE(sink.filter(record));
-}
-
 }  // namespace file
 
 TEST(file_t, Type) {

--- a/tests/sink/file.cpp
+++ b/tests/sink/file.cpp
@@ -68,6 +68,24 @@ TEST(file_t, FromRequiresFilename) {
     EXPECT_THROW(factory<sink::file_t>::from(config), std::logic_error);
 }
 
+TEST(file_t, PatternFromConfig) {
+    using config::testing::mock::node_t;
+
+    StrictMock<config::testing::mock::node_t> config;
+
+    auto n1 = new node_t;
+
+    EXPECT_CALL(config, subscript_key("path"))
+        .Times(1)
+        .WillOnce(Return(n1));
+
+    EXPECT_CALL(*n1, to_string())
+        .Times(1)
+        .WillOnce(Return("/tmp/blackhole.log"));
+
+    factory<sink::file_t>::from(config);
+}
+
 }  // namespace sink
 }  // namespace testing
 }  // namespace blackhole

--- a/tests/sink/file.cpp
+++ b/tests/sink/file.cpp
@@ -65,7 +65,7 @@ TEST(file_t, FromRequiresFilename) {
         .Times(1)
         .WillOnce(Return(nullptr));
 
-    EXPECT_THROW(factory<sink::file_t>::from(config), std::logic_error);
+    EXPECT_THROW(factory<sink::file_t>::from(config), std::invalid_argument);
 }
 
 TEST(file_t, PatternFromConfig) {
@@ -73,19 +73,47 @@ TEST(file_t, PatternFromConfig) {
 
     StrictMock<config::testing::mock::node_t> config;
 
-    auto n1 = new node_t;
+    auto npath = new node_t;
 
     EXPECT_CALL(config, subscript_key("path"))
         .Times(1)
-        .WillOnce(Return(n1));
+        .WillOnce(Return(npath));
 
-    EXPECT_CALL(*n1, to_string())
+    EXPECT_CALL(*npath, to_string())
         .Times(1)
         .WillOnce(Return("/tmp/blackhole.log"));
 
-    const auto file = factory<sink::file_t>::from(config);
+    EXPECT_CALL(config, subscript_key("flush"))
+        .Times(1)
+        .WillOnce(Return(nullptr));
 
-    EXPECT_EQ("/tmp/blackhole.log", file.path());
+    EXPECT_EQ("/tmp/blackhole.log", factory<sink::file_t>::from(config).path());
+}
+
+TEST(file_t, FlushIntervalFromConfig) {
+    using config::testing::mock::node_t;
+
+    StrictMock<config::testing::mock::node_t> config;
+
+    auto npath = new node_t;
+    EXPECT_CALL(config, subscript_key("path"))
+        .Times(1)
+        .WillOnce(Return(npath));
+
+    EXPECT_CALL(*npath, to_string())
+        .Times(1)
+        .WillOnce(Return("/tmp/blackhole.log"));
+
+    auto nflush = new node_t;
+    EXPECT_CALL(config, subscript_key("flush"))
+        .Times(1)
+        .WillOnce(Return(nflush));
+
+    EXPECT_CALL(*nflush, to_uint64())
+        .Times(1)
+        .WillOnce(Return(30));
+
+    factory<sink::file_t>::from(config);
 }
 
 }  // namespace sink

--- a/tests/sink/file.cpp
+++ b/tests/sink/file.cpp
@@ -83,7 +83,9 @@ TEST(file_t, PatternFromConfig) {
         .Times(1)
         .WillOnce(Return("/tmp/blackhole.log"));
 
-    factory<sink::file_t>::from(config);
+    const auto file = factory<sink::file_t>::from(config);
+
+    EXPECT_EQ("/tmp/blackhole.log", file.path());
 }
 
 }  // namespace sink

--- a/tests/sink/null.cpp
+++ b/tests/sink/null.cpp
@@ -16,16 +16,6 @@ using ::testing::StrictMock;
 
 using sink::null_t;
 
-TEST(null_t, FilterOut) {
-    const string_view message("-");
-    const attribute_pack pack;
-    record_t record(42, message, pack);
-
-    null_t sink;
-
-    EXPECT_FALSE(sink.filter(record));
-}
-
 TEST(null_t, type) {
     EXPECT_EQ("null", std::string(factory<sink::null_t>::type()));
 }

--- a/tests/sink/tcp.cpp
+++ b/tests/sink/tcp.cpp
@@ -1,0 +1,144 @@
+#include <boost/asio/ip/tcp.hpp>
+#include <boost/asio/read.hpp>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <blackhole/attribute.hpp>
+#include <blackhole/record.hpp>
+
+#include <blackhole/detail/sink/socket/tcp.hpp>
+
+#include "mocks/node.hpp"
+
+namespace blackhole {
+inline namespace v1 {
+namespace sink {
+namespace testing {
+
+using sink::socket::tcp_t;
+
+using ::testing::Return;
+using ::testing::StrictMock;
+
+TEST(tcp, Host) {
+    EXPECT_EQ("localhost", tcp_t("localhost", 20000).host());
+}
+
+TEST(tcp, Port) {
+    EXPECT_EQ(20000, tcp_t("localhost", 20000).port());
+}
+
+TEST(tcp, SendsData) {
+    boost::asio::io_service io_service;
+    boost::asio::ip::tcp::acceptor acceptor(io_service,
+        boost::asio::ip::tcp::endpoint(boost::asio::ip::tcp::v4(), 0));
+    const auto endpoint = acceptor.local_endpoint();
+
+    tcp_t sink(endpoint.address().to_string(), endpoint.port());
+
+    const string_view message("");
+    const attribute_pack pack;
+    const record_t record(0, message, pack);
+
+    sink.emit(record, "{}");
+
+    boost::asio::ip::tcp::socket socket(io_service);
+    acceptor.accept(socket);
+
+    std::array<char, 2> buffer;
+    boost::asio::ip::tcp::endpoint remote;
+    const auto nread = boost::asio::read(socket, boost::asio::buffer(buffer),
+        boost::asio::transfer_exactly(2));
+
+    ASSERT_EQ(2, nread);
+    EXPECT_EQ('{', buffer[0]);
+    EXPECT_EQ('}', buffer[1]);
+}
+
+TEST(tcp, ThrowsExceptionOnConnectionRefused) {
+    tcp_t sink("127.0.0.1", 1023);
+
+    const string_view message("");
+    const attribute_pack pack;
+    const record_t record(0, message, pack);
+
+    EXPECT_THROW(sink.emit(record, "{}"), std::system_error);
+}
+
+TEST(tcp_t, type) {
+    EXPECT_EQ("tcp", std::string(blackhole::factory<tcp_t>::type()));
+}
+
+TEST(tcp_t, ThrowsIfHostParameterIsMissing) {
+    StrictMock<config::testing::mock::node_t> config;
+
+    EXPECT_CALL(config, subscript_key("host"))
+        .Times(1)
+        .WillOnce(Return(nullptr));
+
+    try {
+        factory<tcp_t>::from(config);
+    } catch (const std::invalid_argument& err) {
+        EXPECT_STREQ(R"(parameter "host" is required)", err.what());
+    }
+}
+
+TEST(tcp_t, ThrowsIfPortParameterIsMissing) {
+    using config::testing::mock::node_t;
+
+    StrictMock<node_t> config;
+
+    auto n1 = new node_t;
+    EXPECT_CALL(config, subscript_key("host"))
+        .Times(1)
+        .WillOnce(Return(n1));
+
+    EXPECT_CALL(*n1, to_string())
+        .Times(1)
+        .WillOnce(Return("localhost"));
+
+    EXPECT_CALL(config, subscript_key("port"))
+        .Times(1)
+        .WillOnce(Return(nullptr));
+
+    try {
+        factory<tcp_t>::from(config);
+    } catch (const std::invalid_argument& err) {
+        EXPECT_STREQ(R"(parameter "port" is required)", err.what());
+    }
+}
+
+TEST(tcp_t, Config) {
+    using config::testing::mock::node_t;
+
+    StrictMock<node_t> config;
+
+    auto n1 = new node_t;
+    EXPECT_CALL(config, subscript_key("host"))
+        .Times(1)
+        .WillOnce(Return(n1));
+
+    EXPECT_CALL(*n1, to_string())
+        .Times(1)
+        .WillOnce(Return("0.0.0.0"));
+
+    auto n2 = new node_t;
+    EXPECT_CALL(config, subscript_key("port"))
+        .Times(1)
+        .WillOnce(Return(n2));
+
+    EXPECT_CALL(*n2, to_uint64())
+        .Times(1)
+        .WillOnce(Return(20000));
+
+    const auto sink = factory<tcp_t>::from(config);
+
+    EXPECT_EQ("0.0.0.0", sink.host());
+    EXPECT_EQ(20000, sink.port());
+}
+
+}  // namespace testing
+}  // namespace sink
+}  // namespace v1
+}  // namespace blackhole


### PR DESCRIPTION
Changes:
------------
- Add TCP sink.
- Add process and thread fields in JSON layout.
- Flush interval for file sink.
- More documentation.
- Extend config interface allowing to check node types (breaks vtable size).
- Remove `filter` method from sinks (breaks vtables).

**All code that uses sinks and configs directly is required to be recompiled.**