### PR TITLE
Optional local timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,19 +116,20 @@ attributes you can place and format every custom attribute you want, as we just 
 
 The Blackhole supports several predefined attributes, with convenient specifications:
 
-| Placeholder              | Description                                                   |
-|--------------------------|---------------------------------------------------------------|
-|{severity:s}              | User provided severity string representation                  |
-|{severity}, {severity:d}  | Numeric severity value                                        |
-|{timestamp:d}             | Number of microseconds since Unix epoch                       |
-|{timestamp:{spec}s}       | String representation using *strftime* specification          |
-|{timestamp}, {timestamp:s}| The same as *{timestamp:{%Y-%m-%d %H:%M:%S.%f}s}*             |
-|{process:s}               | Process name                                                  |
-|{process}, {process:d}    | PID                                                           |
-|{thread}, {thread::x}     | Thread hex id as an opaque value returned by *pthread_self(3)*|
-|{thread:s}                | Thread name or *unnnamed*                                     |
-|{message}                 | Logging message                                               |
-|{...}                     | All user declared attributes                                  |
+| Placeholder              | Description                                                            |
+|--------------------------|------------------------------------------------------------------------|
+|{severity:s}              | User provided severity string representation                           |
+|{severity}, {severity:d}  | Numeric severity value                                                 |
+|{timestamp:d}             | Number of microseconds since Unix epoch                                |
+|{timestamp:{spec}s}       | String representation using *strftime* specification in UTC            |
+|{timestamp:{spec}l}       | String representation using *strftime* specification in local timezone |
+|{timestamp}, {timestamp:s}| The same as *{timestamp:{%Y-%m-%d %H:%M:%S.%f}s}*                      |
+|{process:s}               | Process name                                                           |
+|{process}, {process:d}    | PID                                                                    |
+|{thread}, {thread::x}     | Thread hex id as an opaque value returned by *pthread_self(3)*         |
+|{thread:s}                | Thread name or *unnnamed*                                              |
+|{message}                 | Logging message                                                        |
+|{...}                     | All user declared attributes                                           |
 
 For more information please read the documentation and visit the following links:
 

--- a/include/blackhole/detail/formatter/string/token.hpp
+++ b/include/blackhole/detail/formatter/string/token.hpp
@@ -80,10 +80,11 @@ template<>
 struct timestamp<user> {
     std::string pattern;
     std::string spec;
+    bool gmtime;
     datetime::generator_t generator;
 
     timestamp();
-    timestamp(std::string pattern, std::string spec);
+    timestamp(std::string pattern, std::string spec, bool gmtime);
 };
 
 template<typename T>

--- a/src/formatter/string.cpp
+++ b/src/formatter/string.cpp
@@ -189,7 +189,11 @@ public:
         >(timestamp.time_since_epoch()).count() % 1000000;
 
         std::tm tm;
-        ::gmtime_r(&time, &tm);
+        if (token.gmtime) {
+            ::gmtime_r(&time, &tm);
+        } else {
+            ::localtime_r(&time, &tm);
+        }
 
         fmt::MemoryWriter buffer;
         token.generator(buffer, tm, static_cast<std::uint64_t>(usec));

--- a/src/formatter/string/parser.cpp
+++ b/src/formatter/string/parser.cpp
@@ -100,11 +100,15 @@ public:
         switch (type) {
         case 'd':
             return ph::timestamp<num>(std::move(spec));
+        case 'l':
+            spec[spec.size() - 2] = 's';
+            return extract<false>(spec);
         default:
             return extract(spec);
         }
     }
 
+    template<bool gmtime = true>
     auto extract(const std::string& spec) const -> ph::timestamp<user> {
         // Spec always starts with "{:".
         auto pos = spec.begin() + 2;
@@ -130,7 +134,7 @@ public:
 
         spec_.append(std::string(pos, std::end(spec)));
 
-        return ph::timestamp<user>(std::move(pattern), std::move(spec_));
+        return ph::timestamp<user>(std::move(pattern), std::move(spec_), gmtime);
     }
 };
 

--- a/src/formatter/string/token.cpp
+++ b/src/formatter/string/token.cpp
@@ -46,12 +46,14 @@ timestamp<num>::timestamp(std::string spec) : spec(std::move(spec)) {}
 timestamp<user>::timestamp() :
     pattern("%Y-%m-%d %H:%M:%S.%f"),
     spec("{}"),
+    gmtime(true),
     generator(datetime::make_generator(pattern))
 {}
 
-timestamp<user>::timestamp(std::string pattern, std::string spec) :
+timestamp<user>::timestamp(std::string pattern, std::string spec, bool gmtime) :
     pattern(pattern.empty() ? "%Y-%m-%d %H:%M:%S.%f" : std::move(pattern)),
     spec(std::move(spec)),
+    gmtime(gmtime),
     generator(datetime::make_generator(this->pattern))
 {}
 

--- a/tests/formatter/parser.cpp
+++ b/tests/formatter/parser.cpp
@@ -208,6 +208,7 @@ TEST(parser_t, Timestamp) {
     // NOTE: On empty pattern there is default pattern one.
     EXPECT_EQ("%Y-%m-%d %H:%M:%S.%f", boost::get<timestamp<user>>(*token).pattern);
     EXPECT_EQ("{}", boost::get<timestamp<user>>(*token).spec);
+    EXPECT_TRUE(boost::get<timestamp<user>>(*token).gmtime);
 
     EXPECT_FALSE(parser.next());
 }
@@ -229,6 +230,7 @@ TEST(parser_t, TimestampString) {
     ASSERT_TRUE(!!token);
     EXPECT_EQ("%Y-%m-%d %H:%M:%S.%f %z", boost::get<timestamp<user>>(*token).pattern);
     EXPECT_EQ("{:s}", boost::get<timestamp<user>>(*token).spec);
+    EXPECT_TRUE(boost::get<timestamp<user>>(*token).gmtime);
 
     EXPECT_FALSE(parser.next());
 }
@@ -240,6 +242,32 @@ TEST(parser_t, TimestampSpec) {
     ASSERT_TRUE(!!token);
     EXPECT_EQ("%Y-%m-%d %H:%M:%S.%f", boost::get<timestamp<user>>(*token).pattern);
     EXPECT_EQ("{:<20s}", boost::get<timestamp<user>>(*token).spec);
+
+    EXPECT_FALSE(parser.next());
+}
+
+TEST(parser_t, TimestampLocaltime) {
+    parser_t parser("{timestamp:l}");
+
+    auto token = parser.next();
+    ASSERT_TRUE(!!token);
+
+    // NOTE: On empty pattern there is default pattern one.
+    EXPECT_EQ("%Y-%m-%d %H:%M:%S.%f", boost::get<timestamp<user>>(*token).pattern);
+    EXPECT_EQ("{:s}", boost::get<timestamp<user>>(*token).spec);
+    EXPECT_FALSE(boost::get<timestamp<user>>(*token).gmtime);
+
+    EXPECT_FALSE(parser.next());
+}
+
+TEST(parser_t, TimestampSpecLocaltime) {
+    parser_t parser("{timestamp:<20l}");
+
+    auto token = parser.next();
+    ASSERT_TRUE(!!token);
+    EXPECT_EQ("%Y-%m-%d %H:%M:%S.%f", boost::get<timestamp<user>>(*token).pattern);
+    EXPECT_EQ("{:<20s}", boost::get<timestamp<user>>(*token).spec);
+    EXPECT_FALSE(boost::get<timestamp<user>>(*token).gmtime);
 
     EXPECT_FALSE(parser.next());
 }

--- a/tests/formatter/string.cpp
+++ b/tests/formatter/string.cpp
@@ -512,6 +512,80 @@ TEST(string_t, TimestampSpec) {
     EXPECT_EQ(wr.str(), writer.result().to_string());
 }
 
+TEST(string_t, TimestampLocaltime) {
+    // NOTE: By default %Y-%m-%d %H:%M:%S.%f pattern is used.
+    formatter::string_t formatter("[{timestamp:l}]");
+
+    const string_view message("-");
+    const attribute_pack pack;
+    record_t record(0, message, pack);
+    record.activate();
+
+    const auto timestamp = record.timestamp();
+    const auto time = record_t::clock_type::to_time_t(timestamp);
+    std::tm tm;
+    ::localtime_r(&time, &tm);
+    char buffer[128];
+    const auto len = std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm);
+    fmt::MemoryWriter wr;
+    wr << "[" << fmt::StringRef(buffer, len) << "." << fmt::pad(std::chrono::duration_cast<
+        std::chrono::microseconds
+    >(timestamp.time_since_epoch()).count() % 1000000, 6, '0') << "]";
+
+    writer_t writer;
+    formatter.format(record, writer);
+
+    EXPECT_EQ(wr.str(), writer.result().to_string());
+}
+
+TEST(string_t, TimestampExplicitWithTypeLocaltime) {
+    formatter::string_t formatter("[{timestamp:{%H:%M:%S}l}]");
+
+    const string_view message("-");
+    const attribute_pack pack;
+    record_t record(0, message, pack);
+    record.activate();
+
+    const auto timestamp = record.timestamp();
+    const auto time = record_t::clock_type::to_time_t(timestamp);
+    std::tm tm;
+    ::localtime_r(&time, &tm);
+    char buffer[128];
+    const auto len = std::strftime(buffer, sizeof(buffer), "%H:%M:%S", &tm);
+    fmt::MemoryWriter wr;
+    wr << "[" << fmt::StringRef(buffer, len) << "]";
+
+    writer_t writer;
+    formatter.format(record, writer);
+
+    EXPECT_EQ(wr.str(), writer.result().to_string());
+}
+
+TEST(string_t, TimestampSpecLocaltime) {
+    formatter::string_t formatter("[{timestamp:>30l}]");
+
+    const string_view message("-");
+    const attribute_pack pack;
+    record_t record(0, message, pack);
+    record.activate();
+
+    const auto timestamp = record.timestamp();
+    const auto time = record_t::clock_type::to_time_t(timestamp);
+    std::tm tm;
+    ::localtime_r(&time, &tm);
+    char buffer[128];
+    const auto len = std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", &tm);
+    fmt::MemoryWriter wr;
+    wr << "[    " << fmt::StringRef(buffer, len) << "." << fmt::pad(std::chrono::duration_cast<
+        std::chrono::microseconds
+    >(timestamp.time_since_epoch()).count() % 1000000, 6, '0') << "]";
+
+    writer_t writer;
+    formatter.format(record, writer);
+
+    EXPECT_EQ(wr.str(), writer.result().to_string());
+}
+
 TEST(string_t, TimestampNum) {
     formatter::string_t formatter("[{timestamp:d}]");
 


### PR DESCRIPTION
This PR allows to specify timestamp formatting using local timezone by introducing new type token (l), meaning «localtime».

By default there is UTC as before.

r? @antmat @shindo