### PR TITLE
Fix compilation with boost 1.58

### DIFF
--- a/tests/src/unit/detail/formatter/string/parser.cpp
+++ b/tests/src/unit/detail/formatter/string/parser.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/type_traits/remove_cv.hpp>
 #include <boost/variant/get.hpp>
 
 #include <blackhole/detail/formatter/string/parser.hpp>


### PR DESCRIPTION
When compiling with Boost 1.58, I get the following error:
```
[ 57%] Building CXX object CMakeFiles/blackhole-tests.dir/tests/src/unit/detail/formatter/string/parser.cpp.o
In file included from /Users/vasyan/Projects/blackhole/tests/src/unit/detail/formatter/string/parser.cpp:3:
In file included from /usr/local/include/boost/variant/get.hpp:24:
/usr/local/include/boost/variant/detail/element_index.hpp:38:62: error: no template named 'remove_cv' in namespace 'boost'; did you mean 'std::remove_cv'?
            variant_element_functor<boost::mpl::_1, typename boost::remove_cv<T>::type >
                                                             ^~~~~~~
/Library/Developer/CommandLineTools/usr/bin/../include/c++/v1/type_traits:281:51: note: 'std::remove_cv' declared here
template <class _Tp> struct _LIBCPP_TYPE_VIS_ONLY remove_cv
                                                  ^
1 error generated.
```

It's a bug in boost. Some discussion is here https://groups.google.com/forum/#!topic/boost-devel-archive/EYlnhQKB-3M
