### PR TITLE
Fix build on gcc 5

### DIFF
--- a/bench/cpp14formatter.cpp
+++ b/bench/cpp14formatter.cpp
@@ -1,4 +1,4 @@
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 
 #include <benchmark/benchmark.h>
 

--- a/bench/logger.cpp
+++ b/bench/logger.cpp
@@ -89,7 +89,7 @@ literal_with_args(::benchmark::State& state) {
     state.SetItemsProcessed(state.iterations());
 }
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 static
 void
 literal_with_args_using_cpp14_formatter(::benchmark::State& state) {
@@ -282,7 +282,7 @@ NBENCHMARK("log.lit[args: 1]", literal_with_arg);
 NBENCHMARK("log.lit[args: 6]", literal_with_args);
 
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 NBENCHMARK("log.lit[args: 6 + c++14::fmt]", literal_with_args_using_cpp14_formatter);
 #endif
 

--- a/include/blackhole/extensions/facade.hpp
+++ b/include/blackhole/extensions/facade.hpp
@@ -2,7 +2,7 @@
 
 #include <functional>
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 #include "blackhole/extensions/metaformat.hpp"
 #endif
 
@@ -60,7 +60,7 @@ public:
     template<typename T, typename... Args>
     auto log(int severity, const string_view& pattern, const T& arg, const Args&... args) -> void;
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
     /// Log a message with the given severity level and further formatting using the given pattern
     /// and arguments.
     ///
@@ -114,7 +114,7 @@ logger_facade<Logger>::log(int severity, const string_view& pattern, const attri
     inner().log(severity, pattern, pack);
 }
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 
 template<typename Logger>
 template<std::size_t N, typename T, typename... Args>

--- a/include/blackhole/extensions/metaformat.hpp
+++ b/include/blackhole/extensions/metaformat.hpp
@@ -9,7 +9,7 @@
 
 using blackhole::stdext::string_view;
 
-#if defined(__cpp_constexpr) && __cpp_constexpr >= 201304
+#if (__GNUC__ >= 6 || defined(__clang__)) && defined(__cpp_constexpr) && __cpp_constexpr >= 201304
 
 constexpr
 std::size_t

--- a/tests/src/unit/detail/formatter/string/parser.cpp
+++ b/tests/src/unit/detail/formatter/string/parser.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 
+#include <boost/type_traits/remove_cv.hpp> 
 #include <boost/variant/get.hpp>
 
 #include <blackhole/detail/formatter/string/parser.hpp>


### PR DESCRIPTION
fix #135 
Also i have some problems with building tests:
```
In file included from /root/prog/mblackhole/build/foreign/google-benchmark/include/benchmark/benchmark.h:18:0,
                 from /root/prog/mblackhole/bench/attribute.cpp:1:
/root/prog/mblackhole/build/foreign/google-benchmark/include/benchmark/benchmark_api.h: In function ‘void blackhole::benchmark::from_owned(benchmark::State&)’:
/root/prog/mblackhole/build/foreign/google-benchmark/include/benchmark/benchmark_api.h:211:54: error: inconsistent operand constraints in an ‘asm’
     asm volatile("" : "+rm" (const_cast<Tp&>(value)));
```
But i can't fix it because google-benchmark download from your aws cloud=) i try to use google-benchmark from git master and it works fine