### PR TITLE
Fix debuginfo package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+blackhole (1.1.0-2) unstable; urgency=low
+
+  * Fix empty debuginfo package
+
+ -- Vitaly Isaev <vitalyisaev2@gmail.com>  Thu, 18 Aug 2016 12:41:51 +0300
+
 blackhole (1.1.0-1) unstable; urgency=low
 
   * Added: introducing a new development handler with eye-candy colored

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Blackhole C++ Logger
  Fast C++ logging library with dynamic attributes.
 
-Package: libblackhole-dbg
+Package: blackhole-dbg
 Section: debug
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libblackhole1 (= ${binary:Version})

--- a/debian/control
+++ b/debian/control
@@ -24,7 +24,7 @@ Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: Blackhole C++ Logger
  Fast C++ logging library with dynamic attributes.
 
-Package: blackhole-dbg
+Package: libblackhole-dbg
 Section: debug
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, libblackhole1 (= ${binary:Version})

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,13 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
+DH_VERBOSE = 1
 
 %:
 	dh $@ 
 
+override_dh_auto_configure:
+	cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_VERBOSE_MAKEFILE=ON
+
+.PHONY: override_dh_strip
+override_dh_strip:
+	dh_strip --dbg-package=libblackhole-dbg

--- a/debian/rules
+++ b/debian/rules
@@ -10,4 +10,4 @@ override_dh_auto_configure:
 
 .PHONY: override_dh_strip
 override_dh_strip:
-	dh_strip --dbg-package=libblackhole-dbg
+	dh_strip --dbg-package=blackhole-dbg


### PR DESCRIPTION
Hello! I've noticed that the resulting ```dbg```  is always empty. This PR fixes this issue.