### PR TITLE
feat: optional placeholder with default

### DIFF
--- a/include/blackhole/detail/formatter/string/grammar.hpp
+++ b/include/blackhole/detail/formatter/string/grammar.hpp
@@ -9,6 +9,7 @@ namespace formatter {
 namespace string {
 
 auto parse_leftover(const std::string& pattern) -> ph::leftover_t;
+auto parse_optional(const std::string& pattern) -> ph::generic<optional>;
 
 }  // namespace string
 }  // namespace formatter

--- a/include/blackhole/detail/formatter/string/grammar.hpp
+++ b/include/blackhole/detail/formatter/string/grammar.hpp
@@ -9,7 +9,7 @@ namespace formatter {
 namespace string {
 
 auto parse_leftover(const std::string& pattern) -> ph::leftover_t;
-auto parse_optional(const std::string& pattern) -> ph::generic<optional>;
+auto parse_optional(const std::string& name, const std::string& pattern) -> ph::generic<optional>;
 
 }  // namespace string
 }  // namespace formatter

--- a/include/blackhole/detail/formatter/string/grammar.inl.hpp
+++ b/include/blackhole/detail/formatter/string/grammar.inl.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/fusion/adapted/struct/adapt_struct.hpp>
 #include <boost/optional/optional.hpp>
+#include <boost/variant/variant.hpp>
 
 namespace blackhole {
 inline namespace v1 {
@@ -33,6 +34,15 @@ struct grammar_result_t {
     }
 };
 
+struct optional_result_t {
+    struct extension_t {
+        boost::optional<boost::variant<double, std::string>> otherwise;
+    };
+
+    extension_t extension;
+    std::string spec;
+};
+
 auto parse(std::string pattern) -> grammar_result_t;
 auto parse_pattern(std::string pattern) -> std::vector<ph::leftover_t::token_t>;
 
@@ -44,6 +54,17 @@ auto parse_pattern(std::string pattern) -> std::vector<ph::leftover_t::token_t>;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
+
+typedef boost::optional<boost::variant<double, std::string>> adapt1_type;
+
+BOOST_FUSION_ADAPT_STRUCT(blackhole::detail::formatter::string::optional_result_t::extension_t,
+    (adapt1_type, otherwise)
+)
+
+BOOST_FUSION_ADAPT_STRUCT(blackhole::detail::formatter::string::optional_result_t,
+    (blackhole::detail::formatter::string::optional_result_t::extension_t, extension)
+    (std::string, spec)
+)
 
 BOOST_FUSION_ADAPT_STRUCT(blackhole::detail::formatter::string::grammar_result_t::extension_t,
     (boost::optional<std::string>, pattern)

--- a/include/blackhole/detail/formatter/string/token.hpp
+++ b/include/blackhole/detail/formatter/string/token.hpp
@@ -48,6 +48,7 @@ template<>
 struct generic<optional> : public generic<required> {
     std::string prefix;
     std::string suffix;
+    boost::variant<std::int64_t, double, std::string> otherwise;
 
     generic(std::string name);
     generic(std::string name, std::string spec);

--- a/include/blackhole/detail/formatter/string/token.hpp
+++ b/include/blackhole/detail/formatter/string/token.hpp
@@ -48,7 +48,12 @@ template<>
 struct generic<optional> : public generic<required> {
     std::string prefix;
     std::string suffix;
-    boost::variant<std::int64_t, double, std::string> otherwise;
+
+    boost::variant<
+        std::int64_t,
+        double,
+        std::string
+    > otherwise;
 
     generic(std::string name);
     generic(std::string name, std::string spec);

--- a/src/formatter/string.cpp
+++ b/src/formatter/string.cpp
@@ -92,6 +92,22 @@ public:
     }
 };
 
+class otherwise_visitor : public boost::static_visitor<> {
+    writer_t& writer;
+    const std::string& spec;
+
+public:
+    otherwise_visitor(writer_t& writer, const std::string& spec) noexcept :
+        writer(writer),
+        spec(spec)
+    {}
+
+    template<typename T>
+    auto operator()(T value) const -> void {
+        writer.write(spec, value);
+    }
+};
+
 class pattern_visitor_t : public boost::static_visitor<> {
     writer_t& wr;
     const view_of<attribute_t>::type& attribute;
@@ -252,6 +268,8 @@ public:
             writer.write(token.prefix);
             boost::apply_visitor(view_visitor<spec>(writer, token.spec), value->inner().value);
             writer.write(token.suffix);
+        } else {
+            boost::apply_visitor(otherwise_visitor(writer, token.spec), token.otherwise);
         }
     }
 

--- a/src/formatter/string/grammar.cpp
+++ b/src/formatter/string/grammar.cpp
@@ -187,8 +187,8 @@ auto parse_pattern(std::string pattern) -> std::vector<ph::leftover_t::token_t> 
     return parse<pattern_grammar_t>(std::move(pattern));
 }
 
-auto parse_optional(const std::string& pattern) -> ph::generic<optional> {
-    ph::generic<optional> token("");
+auto parse_optional(const std::string& name, const std::string& pattern) -> ph::generic<optional> {
+    ph::generic<optional> token(name);
 
     const auto result = parse<optional_grammar_t>(pattern);
     token.spec = "{:" + result.spec + "}";

--- a/src/formatter/string/grammar.cpp
+++ b/src/formatter/string/grammar.cpp
@@ -164,7 +164,6 @@ auto parse(std::string pattern) -> typename G::result_type {
             return boost::spirit::qi::parse(it, end, grammar, result);
         } catch (const boost::spirit::qi::expectation_failure<typename G::iterator_type>& err) {
             const auto pos = std::distance(pattern.begin(), err.last);
-            std::cout << std::string(pattern.begin(), pattern.begin() + pos) << std::endl;
             throw parser_error_t(static_cast<std::size_t>(pos), pattern, "malformed input pattern");
         }
     }();

--- a/src/formatter/string/parser.cpp
+++ b/src/formatter/string/parser.cpp
@@ -275,7 +275,11 @@ parser_t::parse_placeholder() -> token_t {
 
                 const auto it = factories.find(name);
                 if (it == factories.end()) {
-                    return ph::generic<required>(std::move(name), std::move(spec));
+                    try {
+                        return parse_optional(spec);
+                    } catch (const std::exception&) {
+                        return ph::generic<required>(std::move(name), std::move(spec));
+                    }
                 } else {
                     return it->second->match(std::move(spec));
                 }

--- a/src/formatter/string/parser.cpp
+++ b/src/formatter/string/parser.cpp
@@ -276,7 +276,7 @@ parser_t::parse_placeholder() -> token_t {
                 const auto it = factories.find(name);
                 if (it == factories.end()) {
                     try {
-                        return parse_optional(spec);
+                        return parse_optional(name, spec);
                     } catch (const std::exception&) {
                         return ph::generic<required>(std::move(name), std::move(spec));
                     }

--- a/tests/src/unit/formatter/string.cpp
+++ b/tests/src/unit/formatter/string.cpp
@@ -242,18 +242,18 @@ TEST(string_t, ThrowsIfGenericAttributeNotFound) {
     EXPECT_THROW(formatter->format(record, writer), std::logic_error);
 }
 
-TEST(DISABLED_string_t, GenericOptional) {
-    auto formatter = builder<string_t>("{protocol}{version:{ - REQUIRED:u}.1f}")
+TEST(string_t, GenericOptionalWhenNotFound) {
+    auto formatter = builder<string_t>("{trace:{42:default}#06x}/{span:#06x}")
         .build();
 
     const string_view message("-");
-    const attribute_list attributes{{"protocol", {"HTTP"}}, {"version", {1.1}}};
+    const attribute_list attributes{{"span", 0}};
     const attribute_pack pack{attributes};
     record_t record(0, message, pack);
     writer_t writer;
     formatter->format(record, writer);
 
-    EXPECT_EQ("HTTP/1.1 - REQUIRED", writer.result().to_string());
+    EXPECT_EQ("0x002a/0x0000", writer.result().to_string());
 }
 
 TEST(string_t, GenericLazyUnspec) {

--- a/tests/src/unit/formatter/string.cpp
+++ b/tests/src/unit/formatter/string.cpp
@@ -256,6 +256,20 @@ TEST(string_t, GenericOptionalWhenNotFound) {
     EXPECT_EQ("0x002a/0x0000", writer.result().to_string());
 }
 
+TEST(string_t, GenericOptionalWhenFound) {
+    auto formatter = builder<string_t>("{trace:{42:default}#06x}/{span:#06x}")
+        .build();
+
+    const string_view message("-");
+    const attribute_list attributes{{"trace", 10}, {"span", 50}};
+    const attribute_pack pack{attributes};
+    record_t record(0, message, pack);
+    writer_t writer;
+    formatter->format(record, writer);
+
+    EXPECT_EQ("0x000a/0x0032", writer.result().to_string());
+}
+
 TEST(string_t, GenericLazyUnspec) {
     auto formatter = builder<string_t>("{protocol}/{version}")
         .build();


### PR DESCRIPTION
For example: `{trace:{42:default}#06x}/{span:#06x}`.

Still open questions:
- Should extensions be positional or named?

Closes #140.