### PR TITLE
fix: extend optional placeholders grammar

### DIFF
--- a/src/formatter/string/grammar.cpp
+++ b/src/formatter/string/grammar.cpp
@@ -13,6 +13,7 @@
 #include <boost/spirit/home/qi/operator/expect.hpp>
 #include <boost/spirit/home/qi/operator/kleene.hpp>
 #include <boost/spirit/home/qi/operator/list.hpp>
+#include <boost/spirit/home/qi/operator/and_predicate.hpp>
 #include <boost/spirit/home/qi/operator/not_predicate.hpp>
 #include <boost/spirit/home/qi/operator/optional.hpp>
 #include <boost/spirit/home/qi/operator/permutation.hpp>
@@ -60,7 +61,7 @@ struct optional_grammar_t : public boost::spirit::qi::grammar<std::string::itera
     boost::spirit::qi::rule<iterator_type, optional_result_t()> grammar;
     boost::spirit::qi::rule<iterator_type, std::string()> otherwise;
     boost::spirit::qi::rule<iterator_type, std::string()> spec;
-    boost::spirit::qi::rule<iterator_type, std::string()> fill;
+    boost::spirit::qi::rule<iterator_type, char()> fill;
     boost::spirit::qi::rule<iterator_type, char()> align;
     boost::spirit::qi::rule<iterator_type, char()> alt;
     boost::spirit::qi::rule<iterator_type, char()> zero;
@@ -79,13 +80,13 @@ optional_grammar_t::optional_grammar_t() :
         | ':' >> otherwise >> spec >> '}'
     ) > qi::eoi;
     otherwise %= qi::lit('{') >> (*(qi::char_ - (qi::lit(":default}") >> !qi::lit('}'))) >> ":default}") % '}';
-    spec  %= -alt >> -zero >> -width >> type;
-    // fill  %= +qi::char_;
-    // align %= qi::char_("<^>");
+    spec  %= -fill >> -align >> -alt >> -zero >> -width >> -precision >> -type;
+    fill  %= qi::char_ >> &align;
+    align %= qi::char_("<^>");
     alt   %= qi::char_('#');
     zero  %= qi::char_('0');
     width %= +qi::digit;
-    // precision %= '.' >> +qi::digit;
+    precision %= qi::char_('.') >> +qi::digit;
     type  %= qi::char_("sdfx");
 }
 

--- a/tests/src/unit/formatter/string.cpp
+++ b/tests/src/unit/formatter/string.cpp
@@ -270,6 +270,34 @@ TEST(string_t, GenericOptionalWhenFound) {
     EXPECT_EQ("0x000a/0x0032", writer.result().to_string());
 }
 
+TEST(string_t, GenericOptionalWithDefaultIntegerAndRealIntegerFormattedAsUnknown) {
+    auto formatter = builder<string_t>("{trace:{0000:default}04}/{span:{0000:default}04}")
+        .build();
+
+    const string_view message("-");
+    const attribute_list attributes{{"span", 50}};
+    const attribute_pack pack{attributes};
+    record_t record(0, message, pack);
+    writer_t writer;
+    formatter->format(record, writer);
+
+    EXPECT_EQ("0000/0050", writer.result().to_string());
+}
+
+TEST(string_t, GenericOptionalWithDefaultIntegerAndRealStringFormattedAsUnknown) {
+    auto formatter = builder<string_t>("{trace:{0000:default}0>4}/{span:{0000:default}0>4}")
+        .build();
+
+    const string_view message("-");
+    const attribute_list attributes{{"span", "50"}};
+    const attribute_pack pack{attributes};
+    record_t record(0, message, pack);
+    writer_t writer;
+    formatter->format(record, writer);
+
+    EXPECT_EQ("0000/0050", writer.result().to_string());
+}
+
 TEST(string_t, GenericLazyUnspec) {
     auto formatter = builder<string_t>("{protocol}/{version}")
         .build();


### PR DESCRIPTION
This change allows to specify fill, align and precision specification
for optional placeholders when configuring the pattern formatter.

Also the type specifier is now optional, allowing to specify no type,
making libfmt to select the proper formatting itself.

This commit should fix a bug, where it’s impossible to specify the
default integral value for string-formatted placeholder.

@shaitan this PR should fix your issue.