### PR TITLE
feat: allow to use captured lambdas as args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - Chronomatic Anomaly - 2017-02-13
+### Added
+- Lambda expressions with capture-list can now be used as formatting arguments. This allows to log arguments that require heavyweight transformation before the result can be used.
+
+For example:
+```c++
+logger.log(0, "[::] - esafronov [10/Oct/2000:13:55:36 -0700] 'GET {} HTTP/1.0' 200 2326",
+    [&](std::ostream& stream) -> std::ostream& {
+        return stream << boost::join(paths, "/");
+    }
+);
+```
+
 ## [1.4.0] - Helya - 2017-02-07
 ### Added
 - TSKV (tab-separated key-value) formatter.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ target_link_libraries(${LIBRARY_NAME}
 # So, adding e.g. functions is no problem, modifying argument lists or removing functions would
 # required the SOVERSION to be incremented. Similar rules hold of course for non-opaque
 # data-structures.
-set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.4.0)
+set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.5.0)
 set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION 1)
 
 if (ENABLE_TESTING_THREADSAFETY)

--- a/bench/logger.cpp
+++ b/bench/logger.cpp
@@ -77,6 +77,24 @@ literal_with_arg(::benchmark::State& state) {
 
 static
 void
+literal_with_lazy_arg(::benchmark::State& state) {
+    root_logger_t root({});
+    logger_facade<root_logger_t> logger(root);
+
+    const auto path = "/porn.png";
+    while (state.KeepRunning()) {
+        logger.log(0, "[::] - esafronov [10/Oct/2000:13:55:36 -0700] 'GET {} HTTP/1.0' 200 2326",
+            [&](std::ostream& stream) -> std::ostream& {
+                return stream << path;
+            }
+        );
+    }
+
+    state.SetItemsProcessed(state.iterations());
+}
+
+static
+void
 literal_with_args(::benchmark::State& state) {
     root_logger_t root({});
     logger_facade<root_logger_t> logger(root);
@@ -279,6 +297,7 @@ NBENCHMARK("log.string", string);
 NBENCHMARK("log.lit", literal);
 NBENCHMARK("log.lit[reject]", literal_reject);
 NBENCHMARK("log.lit[args: 1]", literal_with_arg);
+NBENCHMARK("log.lit[args: 1 (lazy)]", literal_with_lazy_arg);
 NBENCHMARK("log.lit[args: 6]", literal_with_args);
 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+blackhole (1.5.0-1) unstable; urgency=low
+
+  * Added: lambda expressions with capture-list can now be used as formatting 
+    arguments. This allows to log arguments that require heavyweight 
+    transformation before the result can be used.
+
+ -- Evgeny Safronov <division494@gmail.com>  Tue, 14 Feb 2017 17:01:17 +0300
+
 blackhole (1.4.0-1) unstable; urgency=low
 
   * Stabilized nearly added features.

--- a/include/blackhole/extensions/format.hpp
+++ b/include/blackhole/extensions/format.hpp
@@ -2638,11 +2638,33 @@ class BasicArrayWriter : public BasicWriter<Char> {
 typedef BasicArrayWriter<char> ArrayWriter;
 typedef BasicArrayWriter<wchar_t> WArrayWriter;
 
+template<typename T, typename Char>
+typename std::enable_if<
+    std::is_convertible<
+        T,
+        std::function<std::ostream&(std::ostream&)>
+    >::value
+>::type
+invoke_helper(std::basic_ostringstream<Char> &os, const T &v) {
+    v(os);
+}
+
+template<typename T, typename U, typename Char>
+typename std::enable_if<
+    !std::is_convertible<
+        T,
+        std::function<std::ostream&(std::ostream&)>
+    >::value
+>::type
+invoke_helper(std::basic_ostringstream<Char> &os, const U &v) {
+    os << v;
+}
+
 // Formats a value.
 template <typename Char, typename T>
 void format(BasicFormatter<Char> &f, const Char *&format_str, const T &value) {
   std::basic_ostringstream<Char> os;
-  os << value;
+  invoke_helper<T>(os, value);
   std::basic_string<Char> str = os.str();
   internal::Arg arg = internal::MakeValue<Char>(str);
   arg.type = static_cast<internal::Arg::Type>(

--- a/include/blackhole/extensions/format.hpp
+++ b/include/blackhole/extensions/format.hpp
@@ -39,6 +39,7 @@
 #include <stdexcept>
 #include <string>
 #include <map>
+#include <functional> // for functional objects formatting.
 
 #ifndef FMT_USE_IOSTREAMS
 # define FMT_USE_IOSTREAMS 1

--- a/tests/facade.cpp
+++ b/tests/facade.cpp
@@ -100,6 +100,26 @@ TEST(Facade, LazyFormattedLog) {
     });
 }
 
+TEST(Facade, LazyFormattedLogCaptured) {
+    logger_type inner;
+    logger_facade<logger_type> logger(inner);
+
+    attribute_pack expected;
+    writer_t writer;
+
+    EXPECT_CALL(inner, log(severity_t(0), An<const lazy_message_t&>(), expected))
+        .Times(1)
+        .WillOnce(WithArg<1>(Invoke([](const lazy_message_t& message) {
+            EXPECT_EQ("GET /porn.png HTTP/1.0 - {}", message.pattern.to_string());
+            EXPECT_EQ("GET /porn.png HTTP/1.0 - 42", message.supplier().to_string());
+        })));
+
+    const auto captured = 42;
+    logger.log(0, "GET /porn.png HTTP/1.0 - {}", [&](std::ostream& stream) -> std::ostream& {
+        return stream << captured;
+    });
+}
+
 TEST(Facade, FormattedAttributeLog) {
     logger_type inner;
     logger_facade<logger_type> logger(inner);


### PR DESCRIPTION
This commit allows to perform lazy argument formatting using lambdas, that accepts `std::ostream` object. It’s not super-fast, due to usage of `std::ostream` inside `libfmt`, but it works!

For example:
```c++
logger.log(0, "[::] - esafronov [10/Oct/2000:13:55:36 -0700] 'GET {} HTTP/1.0' 200 2326",
    [&](std::ostream& stream) -> std::ostream& {
        return stream << boost::join(paths, "/");
    }
);
```

Performance difference:

```
log.lit[args: 1]        256     256 2668313      3.72516M items/s
log.lit[args: 1 (lazy)] 418     417 1712731      2.28555M items/s
```

@antmat @karitra PTAL, dragons may be there...