### PR TITLE
feat: add `%Es` datetime extension

### DIFF
--- a/include/blackhole/detail/datetime/linux/generator.hpp
+++ b/include/blackhole/detail/datetime/linux/generator.hpp
@@ -16,10 +16,11 @@ struct literal_t {
 };
 
 struct epoch_t {};
+struct epoch_alternative_t {};
 struct usecond_t {};
 
 class generator_t {
-    typedef boost::variant<literal_t, epoch_t, usecond_t> token_t;
+    typedef boost::variant<literal_t, epoch_t, epoch_alternative_t, usecond_t> token_t;
 
     std::vector<token_t> tokens;
 
@@ -27,7 +28,7 @@ public:
     explicit generator_t(std::string pattern);
 
     template<typename Stream>
-    void operator()(Stream& stream, const std::tm& tm, std::uint64_t usec = 0) const;
+    void operator()(Stream& stream, const std::tm& tm, std::uint64_t usec = 0, bool gmtime = true, long tz_offset = 0) const;
 };
 
 auto make_generator(const std::string& pattern) -> generator_t;

--- a/include/blackhole/detail/datetime/other/generator.hpp
+++ b/include/blackhole/detail/datetime/other/generator.hpp
@@ -19,7 +19,7 @@ public:
     generator_t(std::vector<token_t> tokens, std::vector<std::string> literals);
 
     template<typename Stream>
-    auto operator()(Stream& stream, const std::tm& tm, std::uint64_t usec = 0) const -> void;
+    auto operator()(Stream& stream, const std::tm& tm, std::uint64_t usec = 0, bool gmtime = true, long tz_offset = 0) const -> void;
 };
 
 auto make_generator(const std::string& pattern) -> generator_t;

--- a/src/formatter/string.cpp
+++ b/src/formatter/string.cpp
@@ -249,7 +249,7 @@ public:
         }
 
         fmt::MemoryWriter buffer;
-        token.generator(buffer, tm, static_cast<std::uint64_t>(usec));
+        token.generator(buffer, tm, static_cast<std::uint64_t>(usec), token.gmtime, timezone);
         writer.write(token.spec, string_ref(buffer.data(), buffer.size()));
     }
 

--- a/src/formatter/tskv.cpp
+++ b/src/formatter/tskv.cpp
@@ -172,7 +172,7 @@ private:
         }
 
         fmt::MemoryWriter buffer;
-        token.generator(buffer, tm, static_cast<std::uint64_t>(usec));
+        token.generator(buffer, tm, static_cast<std::uint64_t>(usec), token.gmtime, timezone);
 
         add(name, string_view(buffer.data(), buffer.size()));
     }


### PR DESCRIPTION
Emits the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000
(UTC), but unlike strftime `%s` does not make assumptions about how
`tm` was obtained.