### PR TITLE
feat: allow to specify how to pick time in tskv

### DIFF
--- a/include/blackhole/formatter/tskv.hpp
+++ b/include/blackhole/formatter/tskv.hpp
@@ -30,6 +30,9 @@ public:
     auto timestamp(const std::string& name, const std::string& pattern) & -> builder&;
     auto timestamp(const std::string& name, const std::string& pattern) && -> builder&&;
 
+    auto timestamp(const std::string& name, const std::string& pattern, bool gmtime) & -> builder&;
+    auto timestamp(const std::string& name, const std::string& pattern, bool gmtime) && -> builder&&;
+
     auto build() && -> std::unique_ptr<formatter_t>;
 };
 


### PR DESCRIPTION
This commit allows to specify how should blackhole pick the time when
formatting timestamps using TSKV formatter.

Added new option named `gmtime` of type `bool` in the formatter's config:

```json
"formatter": {
    "type": "tskv", 
    "mutate": {
        "epoch_with_microseconds": {"strftime": "%s.%f", "gmtime": false}
    }
}
```