### PR TITLE
v1.6.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ target_link_libraries(${LIBRARY_NAME}
 # So, adding e.g. functions is no problem, modifying argument lists or removing functions would
 # required the SOVERSION to be incremented. Similar rules hold of course for non-opaque
 # data-structures.
-set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.5.0)
+set_target_properties(${LIBRARY_NAME} PROPERTIES VERSION 1.6.0)
 set_target_properties(${LIBRARY_NAME} PROPERTIES SOVERSION 1)
 
 if (ENABLE_TESTING_THREADSAFETY)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,17 @@
+blackhole (1.6.0-1) unstable; urgency=low
+
+  * Added: allow comments and trailing commas in the JSON config.
+  * Added: allow to specify how to pick time in TSKV formatter (#168).
+    This change allows to specify how Blackhole should pick the time during
+    formatting timestamps using TSKV formatter.
+  * Changed: replace deprecated OS X stuff with modern one.
+
+ -- Evgeny Safronov <division494@gmail.com>  Thu, 13 Apr 2017 17:35:32 +0300
+
 blackhole (1.5.0-1) unstable; urgency=low
 
-  * Added: lambda expressions with capture-list can now be used as formatting 
-    arguments. This allows to log arguments that require heavyweight 
+  * Added: lambda expressions with capture-list can now be used as formatting
+    arguments. This allows to log arguments that require heavyweight
     transformation before the result can be used.
 
  -- Evgeny Safronov <division494@gmail.com>  Tue, 14 Feb 2017 17:01:17 +0300

--- a/include/blackhole/formatter/tskv.hpp
+++ b/include/blackhole/formatter/tskv.hpp
@@ -30,6 +30,9 @@ public:
     auto timestamp(const std::string& name, const std::string& pattern) & -> builder&;
     auto timestamp(const std::string& name, const std::string& pattern) && -> builder&&;
 
+    auto timestamp(const std::string& name, const std::string& pattern, bool gmtime) & -> builder&;
+    auto timestamp(const std::string& name, const std::string& pattern, bool gmtime) && -> builder&&;
+
     auto build() && -> std::unique_ptr<formatter_t>;
 };
 


### PR DESCRIPTION
### Added
- Allow comments and trailing commas in the JSON config.
- Allow to specify how to pick time in TSKV formatter (#168).
  This change allows to specify how Blackhole should pick the time during formatting timestamps using TSKV formatter.

### Changed
- Replace deprecated OS X stuff with modern one.