### PR TITLE
Fixed #186: Cannot compile with recent boost (clang/gcc)

### DIFF
--- a/src/sink/socket/tcp.cpp
+++ b/src/sink/socket/tcp.cpp
@@ -25,8 +25,13 @@ typedef protocol_type::endpoint endpoint_type;
 
 namespace {
 
+#if BOOST_VERSION >= 106600
+template<typename Protocol, typename Iterator>
+auto do_connect(boost::asio::basic_socket<Protocol>& s,
+#else
 template<typename Protocol, typename SocketService, typename Iterator>
 auto do_connect(boost::asio::basic_socket<Protocol, SocketService>& s,
+#endif
                 Iterator begin,
                 Iterator end,
                 boost::system::error_code& ec) -> Iterator
@@ -50,8 +55,13 @@ auto do_connect(boost::asio::basic_socket<Protocol, SocketService>& s,
     return end;
 }
 
+#if BOOST_VERSION >= 106600
+template <typename Protocol, typename Iterator>
+auto do_connect(boost::asio::basic_socket<Protocol>& s, Iterator begin) -> Iterator {
+#else
 template <typename Protocol, typename SocketService, typename Iterator>
 auto do_connect(boost::asio::basic_socket<Protocol, SocketService>& s, Iterator begin) -> Iterator {
+#endif
     boost::system::error_code ec;
     Iterator end = typename Protocol::resolver::iterator();
     Iterator result = do_connect(s, begin, end, ec);

--- a/src/sink/socket/tcp.hpp
+++ b/src/sink/socket/tcp.hpp
@@ -2,6 +2,7 @@
 
 #include <mutex>
 
+#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
 #include "blackhole/sink.hpp"

--- a/src/sink/socket/udp.hpp
+++ b/src/sink/socket/udp.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <boost/asio/io_service.hpp>
 #include <boost/asio/ip/udp.hpp>
 
 #include "blackhole/sink.hpp"


### PR DESCRIPTION
With boost version 1.66.0 the template parameters of basic_socket were changed and additional includes are needed. 